### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,4 +758,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for @muhittincamdali/iOSFirebaseTools](https://starchart.cc/muhittincamdali/iOSFirebaseTools.svg)](https://github.com/muhittincamdali/iOSFirebaseTools/stargazers) 


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.